### PR TITLE
Modul Confirmation Text

### DIFF
--- a/dca/tl_module.php
+++ b/dca/tl_module.php
@@ -29,5 +29,5 @@
 /**
  * Palettes
  */
-$GLOBALS['TL_DCA']['tl_module']['palettes']['ajaxform'] = '{title_legend},name,headline,type;{include_legend},form;{text_legend},text;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
+$GLOBALS['TL_DCA']['tl_module']['palettes']['ajaxform'] = '{title_legend},name,headline,type;{include_legend},form;{text_legend},richtext;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
 


### PR DESCRIPTION
In Abhängigkeit der Extension _module_richtext_ von Felix Pfeiffer, funktioniert auch das Textfeld im Modul, habe daher in tl_module.php, "text" durch "richtext" ersetzt.
