### PR TITLE
Pass parent content or module model to templates

### DIFF
--- a/AjaxForm.php
+++ b/AjaxForm.php
@@ -36,6 +36,9 @@ class AjaxForm extends \Form
         if (version_compare(VERSION, '4.4', '>=')) {
             $this->tableless = true;
         }
+        
+        // Pass parent content or module model to the ajax form templates
+        $this->parentModel = $this->objParent;
 
         if (\Environment::get('isAjaxRequest') && \Environment::get('httpContaoAjaxForm') === $formId) {
             $this->strTemplate = 'ajaxform_inline';
@@ -48,9 +51,6 @@ class AjaxForm extends \Form
         if ($this->customTpl === 'form_wrapper') {
             $this->customTpl = $this->strTemplate;
         }
-        
-        // Pass parent content or module model to the ajax form templates
-        $this->arrData['objParent'] = $this->objParent;
 
         return parent::generate();
     }
@@ -61,6 +61,7 @@ class AjaxForm extends \Form
     public static function reload()
     {
         static::$objStatic->Template = new \FrontendTemplate('ajaxform_confirm');
+        static::$objStatic->Template->parentModel = static::$objStatic->objParent;
         static::$objStatic->Template->message = static::$objStatic->objParent->text;
 
         if (\Environment::get('isAjaxRequest')) {

--- a/AjaxForm.php
+++ b/AjaxForm.php
@@ -48,6 +48,9 @@ class AjaxForm extends \Form
         if ($this->customTpl === 'form_wrapper') {
             $this->customTpl = $this->strTemplate;
         }
+        
+        // Pass parent content or module model to the ajax form templates
+        $this->arrData['objParent'] = $this->objParent;
 
         return parent::generate();
     }


### PR DESCRIPTION
This allows for extending the content or module model with e.g. another text field to accompany the form. 
You have access to the whole content/module model in the form templates.