### PR TITLE
Use node.append in order to execute scripts

### DIFF
--- a/templates/ajaxform.html5
+++ b/templates/ajaxform.html5
@@ -72,7 +72,8 @@
         }
 
         form.action = action;
-        form.innerHTML = data;
+        form.innerHTML = '';
+        form.append(document.createRange().createContextualFragment(data));
         addButtonEvents(form);
     }
 


### PR DESCRIPTION
Currently, if you have a custom `ajaxform_confirm` template with a `<script>`, then that JavaScript won't be executed. This PR changes that by using `.append` rather than just `.innerHTML = …` - which will also parse and execute `<script>`.