### PR TITLE
[Bugfix] Remove obsolete tableless (Removed since Contao 4.0.0)

### DIFF
--- a/templates/ajaxform.html5
+++ b/templates/ajaxform.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<div class="<?php echo $this->class; ?> <?php echo $this->tableless ? 'tableless' : 'tableform'; ?> block"<?php echo $this->cssID; ?><?php if ($this->style): ?> style="<?php echo $this->style; ?>"<?php endif; ?>>
+<div class="<?php echo $this->class; ?> block"<?php echo $this->cssID; ?><?php if ($this->style): ?> style="<?php echo $this->style; ?>"<?php endif; ?>>
 <?php if ($this->headline): ?>
 
 <<?php echo $this->hl; ?>><?php echo $this->headline; ?></<?php echo $this->hl; ?>>
@@ -14,11 +14,7 @@
 <input type="hidden" name="MAX_FILE_SIZE" value="<?php echo $this->maxFileSize; ?>">
 <?php endif; ?>
 <?php echo $this->hidden; ?>
-<?php if (!$this->tableless): ?>
-<table>
 <?php echo $this->fields; ?>
-</table>
-<?php else: echo $this->fields; endif; ?>
 </div>
 </form>
 

--- a/templates/ajaxform_inline.html5
+++ b/templates/ajaxform_inline.html5
@@ -5,9 +5,5 @@
 <input type="hidden" name="MAX_FILE_SIZE" value="<?php echo $this->maxFileSize; ?>">
 <?php endif; ?>
 <?php echo $this->hidden; ?>
-<?php if (!$this->tableless): ?>
-<table>
 <?php echo $this->fields; ?>
-</table>
-<?php else: echo $this->fields; endif; ?>
 </div>


### PR DESCRIPTION
### What does this PR fix?
This PR fixes the issue with empty table elements appearing when using the ajaxform.

### Reason for removing it:
As seen here, the option has been removed in 2015:
https://github.com/contao/core-bundle/commit/e5b89517a4f250d9c5a874ba1e23364afe23aae9

### Explain the bug:
In the past, we've encountered a few issues where our styles would show an empty 

```<table></table>``` after the form.

This has happened when updating to PHP8.*.

The reason is that the option ``$this->tableless`` is not given; 
thus the forms will get wrapped by a <table>. Due to this <table> having invalid html tags inside ```divs etc.```, the browser won't validate it correctly and moves the empty ```<table></table>``` block below:
![image](https://user-images.githubusercontent.com/55794780/222749287-366f61f5-f136-4ac1-b8f0-2f0169dcc7e7.png)

![image](https://user-images.githubusercontent.com/55794780/222749093-7c7784d5-74ed-4a9f-b468-2d144ce1405d.png)
